### PR TITLE
Add conditional error to ExternalTask worker

### DIFF
--- a/Aktivierungs-E-Mails-Prozess.bpmn
+++ b/Aktivierungs-E-Mails-Prozess.bpmn
@@ -62,6 +62,7 @@
       <bpmn:outgoing>SequenceFlow_1tiy5gs</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:serviceTask id="Task_0rf7p74" name="Rabattcode über 10 EUR versenden" camunda:type="external" camunda:topic="RabattcodeVersenden">
+      <bpmn:documentation>"cartAmount" von 42 verursacht hier zu Demonstrationszwecken einen Fehler</bpmn:documentation>
       <bpmn:extensionElements>
         <camunda:properties>
           <camunda:property name="method" value="" />

--- a/external-task-worker/index.js
+++ b/external-task-worker/index.js
@@ -21,6 +21,10 @@ function validateCartAmount(cartAmount) {
     throw new Error('Cart amount must not be a negative number.');
   }
 
+  if(cartAmountAsNumber === 42) {
+    throw new Error('Cart amount is not the answer to everything.\n\nBy the way, this is a multiline\nerror message!');
+  }
+
   return true;
 }
 


### PR DESCRIPTION
Erzeugt einen Fehler mit "multiline error message" im ExternalTask-Worker, wenn als Warenkorbwert 42 angegeben wird.